### PR TITLE
Add artifactory publishing and improve copyright notice

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,31 +23,16 @@ subprojects {
 
 ext.verifyKeystore()
 
-try {
-    def grgit = org.ajoberstar.grgit.Grgit.open(dir: '.')
-    def lastCommit = grgit.head()
-
-    project.ext.versionNum = grgit.log(includes:['HEAD']).size()
-    project.ext.versionName = grgit.describe()
-    project.ext.versionDate = lastCommit.getDate()
-    if (project.ext.versionName == null) {
-        project.ext.versionName = 'DEV'
-    }
-} catch (Exception ex) {
-    project.ext.versionNum = 0
-    project.ext.versionName = 'DEV'
-    project.ext.versionDate = new Date()
-}
-
 project.ext.minSdkVersion = 16
 project.ext.compileSdkVersion = 27
 project.ext.buildToolsVersion = '27.0.3'
 project.ext.supportLibVersion = '27.1.1'
+project.ext.versionID = "0.7.0"
+project.ext.versionName = """$versionID-skyscanner"""
 
 task showVersion {
     doLast {
-        logger.lifecycle("Version ID: " + project.versionNum)
+        logger.lifecycle("Version ID: " + project.versionID)
         logger.lifecycle("Version Name: " + project.versionName)
-        logger.lifecycle("Version Date: " + project.versionDate)
     }
 }

--- a/config/android-common.gradle
+++ b/config/android-common.gradle
@@ -4,7 +4,7 @@ android {
     defaultConfig {
         minSdkVersion rootProject.minSdkVersion
         targetSdkVersion rootProject.compileSdkVersion
-        versionCode rootProject.versionNum
+        versionCode getVersionCode()
         versionName rootProject.versionName
     }
     sourceSets {
@@ -43,4 +43,10 @@ task sourcesJar(type: Jar, dependsOn:'generateReleaseSources') {
 
 tasks.withType(JavaCompile) {
     options.compilerArgs << "-Xlint:deprecation" << "-Xlint:unchecked"
+}
+
+static def getVersionCode() {
+    def date = new Date()
+    def formattedDate = date.format('yyyyMMddHHmmss')
+    return formattedDate
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 
 apply from: '../config/android-common.gradle'
+apply from: 'gradle-maven-push.gradle'
 
 group = "net.openid"
 version = rootProject.versionName
@@ -53,7 +54,6 @@ bintray {
         version {
             name = rootProject.versionName
             desc = "AppAuth for Android"
-            released = rootProject.versionDate
             vcsTag = rootProject.versionName
         }
     }

--- a/library/gradle-maven-push.gradle
+++ b/library/gradle-maven-push.gradle
@@ -1,0 +1,76 @@
+apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'maven-publish'
+
+def artifactoryURL = "https://artifactory.skyscannertools.net/artifactory/infrastructure-maven"
+
+task sourceJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier "source"
+}
+
+afterEvaluate { project ->
+
+    project.ext.getJFrogPassword = {
+        if (project.hasProperty("SKYSCANNER_ARTIFACTORY_MAVEN_PASSWORD")) {
+            return project.property("SKYSCANNER_ARTIFACTORY_MAVEN_PASSWORD")
+        }
+        return ""
+    }
+
+    project.ext.getJFrogUsername = {
+        if (project.hasProperty("SKYSCANNER_ARTIFACTORY_MAVEN_USER")) {
+            return project.property("SKYSCANNER_ARTIFACTORY_MAVEN_USER")
+        }
+        return ""
+    }
+
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                groupId 'net.openid'
+                artifactId 'appauth'
+                version versionName
+                description description
+
+                artifact bundleRelease
+                artifact sourceJar
+
+                pom.withXml {
+
+                    def dependenciesNode = asNode().appendNode('dependencies')
+                    //Iterate over the compile dependencies (we don't want the test ones), adding a <dependency> node for each
+                    project.configurations.implementation.allDependencies.each {
+                        if (it.group != null && (it.name != null || "unspecified" == it.name) && it.version != null) {
+                            def dependencyNode = dependenciesNode.appendNode('dependency')
+                            dependencyNode.appendNode('groupId', it.group)
+                            dependencyNode.appendNode('artifactId', it.name)
+                            dependencyNode.appendNode('version', it.version)
+                        }
+                    }
+                }
+            }
+        }
+
+        repositories {
+            maven {
+                url "$artifactoryURL"
+                credentials {
+                    username "${project.getJFrogUsername()}"
+                    password "${project.getJFrogPassword()}"
+                }
+            }
+        }
+    }
+
+    task checkMavenCredentials(type: Exec) {
+        outputs.upToDateWhen { false }
+        workingDir './'
+        commandLine(['curl',
+                     '--silent',
+                     '--fail',
+                     '-I',
+                     '-u',
+                     "${project.getJFrogUsername()}:${project.getJFrogPassword()}",
+                     "$artifactoryURL"])
+    }
+}

--- a/library/java/net/openid/appauth/AuthorizationManagementActivity.java
+++ b/library/java/net/openid/appauth/AuthorizationManagementActivity.java
@@ -10,6 +10,10 @@
  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * Copyright 2020 Skyscanner
+ * Changes made to the original file:
+  - Nullability check for the mAuthIntent, finishing the activity if so.
  */
 
 package net.openid.appauth;


### PR DESCRIPTION
## Problem

We want to publish this library to our internal Artifactory, overcoming frequent Jitpack downtime issues

## Solution

- Add publishing to artifactory. [First version](https://artifactory.skyscannertools.net/artifactory/infrastructure-maven/net/openid/appauth) published already.
- Version 0.7.0-skyscanner was chosen because it references the version of the original project at the time of the fork (0.7.0)
- Improve copyright notice