### PR TITLE
Handle SecurityException when warming up Chrome Custom Tab service

### DIFF
--- a/library/java/net/openid/appauth/browser/CustomTabManager.java
+++ b/library/java/net/openid/appauth/browser/CustomTabManager.java
@@ -81,8 +81,13 @@ public class CustomTabManager {
             public void onCustomTabsServiceConnected(ComponentName componentName,
                                                      CustomTabsClient customTabsClient) {
                 Logger.debug("CustomTabsService is connected");
-                customTabsClient.warmup(0);
-                setClient(customTabsClient);
+                try {
+                    customTabsClient.warmup(0);
+                    setClient(customTabsClient);
+                } catch (SecurityException ex) {
+                    Logger.error("CustomTabsService failed to warmup", ex);
+                    setClient(null);
+                }
             }
 
             private void setClient(@Nullable CustomTabsClient client) {


### PR DESCRIPTION
Handle SecurityException when warming up Chrome Custom Tab service to fix a crash on some devices